### PR TITLE
Change the way the clipping is calculated in curtain mode

### DIFF
--- a/src/openseadragon-curtain-sync.js
+++ b/src/openseadragon-curtain-sync.js
@@ -189,7 +189,7 @@
           imageSize = tiledImage.getContentSize();
           imagePos = tiledImage.viewportToImageCoordinates(viewportPos);
           var x = Math.min(imageSize.x, Math.max(0, imagePos.x));
-          clip = new OpenSeadragon.Rect(x, 0, imageSize.x, imageSize.y);
+          clip = new OpenSeadragon.Rect(x, 0, imageSize.x - x, imageSize.y);
           tiledImage.setClip(clip);
         }
       }
@@ -200,7 +200,7 @@
           imageSize = tiledImage.getContentSize();
           imagePos = tiledImage.viewportToImageCoordinates(viewportPos);
           var y = Math.min(imageSize.y, Math.max(0, imagePos.y));
-          clip = new OpenSeadragon.Rect(0, y, imageSize.x, imageSize.y);
+          clip = new OpenSeadragon.Rect(0, y, imageSize.x, imageSize.y - y);
           tiledImage.setClip(clip);
         }
       }


### PR DESCRIPTION
When using a navigator, the view in the navigator resize to find
the new minimum rectangle that can encompass all images. When we pass
the new image size without subtracting the clipped part, we get a new
size with the original size plus the clipped part. This causes that
the minimum rectangle found is the maximum size plus the clipped part.

In other words, it does not take into account the new width.

### This is the original behavior (navigator is in the top-right):
- When the "curtain" is all the way to one side, the navigator shows the correct size.
<img width="1374" alt="Screen Shot 2021-07-11 at 9 36 26 PM" src="https://user-images.githubusercontent.com/35913846/125361930-ac63f000-e333-11eb-92b6-c68212ffeedd.png">

- But when we move the curtain, the navigator resizes the images in the view, because it thinks the clipped image width is it's start clipping point plus the original width.
<img width="1366" alt="Screen Shot 2021-07-12 at 4 56 45 PM" src="https://user-images.githubusercontent.com/35913846/125362165-0d8bc380-e334-11eb-8752-f2c43692f681.png">

- It also happens with height
<img width="1330" alt="Screen Shot 2021-07-12 at 4 56 35 PM" src="https://user-images.githubusercontent.com/35913846/125362422-812dd080-e334-11eb-9f9b-eb2f73fd7f9a.png">



### This is the new behavior:
- Width is correctly calculated.
<img width="1349" alt="Screen Shot 2021-07-12 at 4 53 44 PM" src="https://user-images.githubusercontent.com/35913846/125362216-27c5a180-e334-11eb-9b26-e15f0f0b7781.png">
<img width="1341" alt="Screen Shot 2021-07-12 at 4 56 02 PM" src="https://user-images.githubusercontent.com/35913846/125362610-ce11a700-e334-11eb-9623-92cbe562935d.png">